### PR TITLE
WiFi: fix typo in function names

### DIFF
--- a/src/WiFi.cpp
+++ b/src/WiFi.cpp
@@ -222,17 +222,17 @@ int8_t WiFiClass::scanNetworks()
 
 char* WiFiClass::SSID(uint8_t networkItem)
 {
-	return WiFiDrv::getSSIDNetoworks(networkItem);
+	return WiFiDrv::getSSIDNetworks(networkItem);
 }
 
 int32_t WiFiClass::RSSI(uint8_t networkItem)
 {
-	return WiFiDrv::getRSSINetoworks(networkItem);
+	return WiFiDrv::getRSSINetworks(networkItem);
 }
 
 uint8_t WiFiClass::encryptionType(uint8_t networkItem)
 {
-    return WiFiDrv::getEncTypeNetowrks(networkItem);
+    return WiFiDrv::getEncTypeNetworks(networkItem);
 }
 
 uint8_t WiFiClass::status()

--- a/src/utility/wifi_drv.cpp
+++ b/src/utility/wifi_drv.cpp
@@ -437,7 +437,7 @@ uint8_t WiFiDrv::getScanNetworks()
     return ssidListNum;
 }
 
-char* WiFiDrv::getSSIDNetoworks(uint8_t networkItem)
+char* WiFiDrv::getSSIDNetworks(uint8_t networkItem)
 {
 	if (networkItem >= WL_NETWORKS_LIST_MAXNUM)
 		return NULL;
@@ -445,7 +445,7 @@ char* WiFiDrv::getSSIDNetoworks(uint8_t networkItem)
 	return _networkSsid[networkItem];
 }
 
-uint8_t WiFiDrv::getEncTypeNetowrks(uint8_t networkItem)
+uint8_t WiFiDrv::getEncTypeNetworks(uint8_t networkItem)
 {
 	if (networkItem >= WL_NETWORKS_LIST_MAXNUM)
 		return NULL;
@@ -470,7 +470,7 @@ uint8_t WiFiDrv::getEncTypeNetowrks(uint8_t networkItem)
     return encType;
 }
 
-int32_t WiFiDrv::getRSSINetoworks(uint8_t networkItem)
+int32_t WiFiDrv::getRSSINetworks(uint8_t networkItem)
 {
 	if (networkItem >= WL_NETWORKS_LIST_MAXNUM)
 		return NULL;

--- a/src/utility/wifi_drv.h
+++ b/src/utility/wifi_drv.h
@@ -223,7 +223,7 @@ public:
 	 *
      * return: ssid string of the specified item on the networks scanned list
      */
-    static char* getSSIDNetoworks(uint8_t networkItem);
+    static char* getSSIDNetworks(uint8_t networkItem);
 
     /*
      * Return the RSSI of the networks discovered during the scanNetworks
@@ -232,7 +232,7 @@ public:
 	 *
      * return: signed value of RSSI of the specified item on the networks scanned list
      */
-    static int32_t getRSSINetoworks(uint8_t networkItem);
+    static int32_t getRSSINetworks(uint8_t networkItem);
 
     /*
      * Return the encryption type of the networks discovered during the scanNetworks
@@ -241,7 +241,7 @@ public:
 	 *
      * return: encryption type (enum wl_enc_type) of the specified item on the networks scanned list
      */
-    static uint8_t getEncTypeNetowrks(uint8_t networkItem);
+    static uint8_t getEncTypeNetworks(uint8_t networkItem);
 
     /*
      * Resolve the given hostname to an IP address.


### PR DESCRIPTION
3 function names had a typo: "netowork,  "netowrk". This fixes it.