### PR TITLE
Add diagnostic pragma for unused variable

### DIFF
--- a/src/utility/spi_drv.h
+++ b/src/utility/spi_drv.h
@@ -38,7 +38,10 @@
 	SpiDrv::waitForSlaveReady();  \
 	SpiDrv::spiSlaveSelect();
 
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-variable"
+static bool initialized = false;
+#pragma GCC diagnostic pop
 static bool initialized = false;
 
 class SpiDrv

--- a/src/utility/spi_drv.h
+++ b/src/utility/spi_drv.h
@@ -38,6 +38,7 @@
 	SpiDrv::waitForSlaveReady();  \
 	SpiDrv::spiSlaveSelect();
 
+#pragma GCC diagnostic ignored "-Wunused-variable"
 static bool initialized = false;
 
 class SpiDrv


### PR DESCRIPTION
When compiling with `-Wall` and `-Wextra` GCC flags, a warning is reported about the `initialized` variable:

```text
  In file included from /home/runner/Arduino/libraries/WiFi/src/utility/spi_drv.cpp:22:0:
  /home/runner/Arduino/libraries/WiFi/src/utility/spi_drv.h: At global scope:
  /home/runner/Arduino/libraries/WiFi/src/utility/spi_drv.h:41:13: warning: 'initialized' defined but not used [-Wunused-variable]
   static bool initialized = false;
               ^~~~~~~~~~~
```

However, this variable is used in several macros.

Adding this diagnostic pragma suppresses the warning.

A better solution would be to re-architect the library to avoid the `WAIT_FOR_SLAVE_SELECT` macro in favor of a proper function but it is unclear how this would impact other targets.