### PR TITLE
Remove false claim of zero argument `WiFi.begin` support from docs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -9,7 +9,6 @@ Initializes the WiFi library's network settings and provides the current status.
 
 #### Syntax
 ```
-WiFi.begin();
 WiFi.begin(ssid);
 WiFi.begin(ssid, pass);
 WiFi.begin(ssid, keyIndex, key);


### PR DESCRIPTION
The API documentation claimed that calling `WiFi.begin` without arguments is supported. This is and has always been incorrect.

The false information is hereby removed from the documentation.

Fixes https://github.com/arduino-libraries/WiFi/issues/69